### PR TITLE
修改ShallowCopy试题测试和答案

### DIFF
--- a/bin/questions/05_shallowCopy/Test.js
+++ b/bin/questions/05_shallowCopy/Test.js
@@ -10,7 +10,9 @@ describe('shallowCopy', function() {
 
     it('basic array copy', function() {
         var test = ['china', 'japan', 'america'];
-        assert.deepEqual(shallowCopy(test), _.clone(test), '简单字符串数组浅拷贝错误');
+        assert.equal(shallowCopy(test).length, test.length, '简单数组对象不可枚举属性length错误');
+        assert.equal(Array.isArray(shallowCopy(test)), true, '简单数组浅拷贝错误，返回值不是数组对象');
+        assert.deepEqual(shallowCopy(test), _.clone(test), '简单数组浅拷贝错误，内容错误');
     });
 
     it('basic object array', function() {
@@ -19,7 +21,7 @@ describe('shallowCopy', function() {
         }, {
             name: 'world'
         }];
-        assert.deepEqual(shallowCopy(test), _.clone(test), '简单对象数组浅拷贝错误');
+        assert.deepEqual(shallowCopy(test), _.clone(test), '简单对象数组浅拷贝错误，内容错误');
     });
 
     it('basic object array', function() {
@@ -35,4 +37,12 @@ describe('shallowCopy', function() {
         assert.equal(copied[0].value, test[0].value, '浅拷贝不应该影响里面reference的值');
     });
 
+    it('basic object', function() {
+        var test = {
+            name: 'north',
+            value: 25
+        };
+        assert.equal(shallowCopy(test).length, undefined, '简单对象浅拷贝错误，对象不应该拥有length属性');
+        assert.deepEqual(shallowCopy(test), _.clone(test), '简单对象浅拷贝错误，内容错误');
+    });
 });

--- a/bin/questions/05_shallowCopy/answer.js
+++ b/bin/questions/05_shallowCopy/answer.js
@@ -15,7 +15,7 @@
  *
  **/
 var shallowCopy = function(value) {
-    return Array.prototype.slice.apply(value);
+    return Object.assign(new (Object.getPrototypeOf(value).constructor)(),value);
 };
 
 module.exports = shallowCopy;


### PR DESCRIPTION
试题需求中有对plain object进行的操作，而所给答案使用Array slice方法操作之后返回的是一个数组，残留有数组上的其他属性和方法。

我添加了一些测试以稍微严格的方式来约束返回值类型。
并且修改了答案以通过新的测试。
